### PR TITLE
 …

### DIFF
--- a/src/GuzzleCache/GuzzleCacheServiceProvider.php
+++ b/src/GuzzleCache/GuzzleCacheServiceProvider.php
@@ -1,14 +1,16 @@
-<?php namespace Remic\GuzzleCache;
+<?php
+
+namespace Remic\GuzzleCache;
 
 use Illuminate\Support\ServiceProvider;
 
 /**
  * A Laravel 5's package template.
  */
-class GuzzleCacheServiceProvider extends ServiceProvider {
-
+class GuzzleCacheServiceProvider extends ServiceProvider
+{
     /**
-     * This will be used to register config & view in 
+     * This will be used to register config & view in
      * your package namespace.
      *
      * --> Replace with your package name <--
@@ -17,23 +19,25 @@ class GuzzleCacheServiceProvider extends ServiceProvider {
 
     /**
      * Bootstrap the application services.
-     *
-     * @return void
      */
     public function boot()
-    {           
-        $this->app->bindShared('Remic\GuzzleCache\Factory',function ($app) {
+    {
+        // Check is performed as this function doesn't exist in Lumen
+        if (function_exists('config_path')) {
+            $configPath = __DIR__.'/../config/config.php';
+
+            $this->publishes([$configPath => config_path($this->packageName.'.php')], 'config');
+        }
+
+        $this->app->bindShared('Remic\GuzzleCache\Factory', function ($app) {
             $lifetime = config('guzzlecache.lifetime');
             $customStore = config('guzzlecache.custom_store');
             $cachePrefix = config('guzzlecache.cache_prefix');
 
-            if(is_null($customStore) || $customStore == '')
-            {
+            if (is_null($customStore) || $customStore == '') {
                 // use the default cache store
                 return new Factory($app['cache']->store(), $lifetime, $cachePrefix);
-            }
-            else
-            {
+            } else {
                 // use custom store
                 return new Factory($app['cache']->store($customStore), $lifetime, $cachePrefix);
             }
@@ -46,15 +50,10 @@ class GuzzleCacheServiceProvider extends ServiceProvider {
 
     /**
      * Register the application services.
-     *
-     * @return void
      */
     public function register()
     {
-        $this->publishes([
-            __DIR__.'/../config/config.php' => config_path($this->packageName.'.php'),
-        ]);
-
+        $configPath = __DIR__.'/../config/config.php';
+        $this->mergeConfigFrom($configPath, $this->packageName);
     }
-
 }


### PR DESCRIPTION
In the ServiceProvider, merge the guzzlecache config values with the app level config values. This allows the user to override the config values on a selective basis. 

In the CacheSubscriber, cache the response body as a string and separate from the response, then when retrieving from the cache, create a new Stream from the body string and set the stream as the body on the cached response.  I did this because I need to save the payload on the request, though guzzle saves in the the PHP temp folder, which get deleted every request.  So I saved the body as text when caching, and when you retrieve the data from the cache, I create a new stream for the request, so guzzle doesn't notice anything different.

Also wrapped the config_path function call in the boot phase of the ServiceProvider with a check to see if the function exists so that it can work with Lumen.
